### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,5 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /mytime.md
+/temp/.ezlogger_config.ini
+/temp/ez_logger_global_config.ini

--- a/.notes/Using this for all ReportType ComboBoxes.md
+++ b/.notes/Using this for all ReportType ComboBoxes.md
@@ -1,0 +1,120 @@
+# Shared ComboBox Population and Syncing Strategy in EZLogger
+
+## Purpose
+This document explains how the report type ComboBoxes in `ReportWizardPanel` and `ReportTypeView` are populated using a shared list, how the selected item is passed between the forms, and how this architecture can be reused to populate other controls like ListBoxes or additional ComboBoxes.
+
+## Summary of Behavior
+- The report type list is defined once in `ReportTypeHandler.GetReportTypes()`.
+- Both `ReportWizardPanel` and `ReportTypeView` use this list to populate their ComboBoxes.
+- When a user opens the `ReportTypeView` form, the current selection is passed to it.
+- If the user changes the selection and closes the form, the new value is synced back to the main panel.
+
+---
+
+## Components and Key Logic
+
+### 1. Shared Method in `ReportTypeHandler.vb`
+```vb
+Public Function GetReportTypes() As List(Of String)
+    Return New List(Of String) From {
+        "1370(b)(1)",
+        "1372(a)(1)",
+        "UNLIKELY 1370(b)(1)",
+        "PPR"
+    }
+End Function
+```
+
+### 2. Populate ComboBox in `ReportWizardPanel.xaml.vb`
+```vb
+Private Sub ReportWizardPanel_Loaded(sender As Object, e As RoutedEventArgs) Handles Me.Loaded
+    ReportTypeCbo.ItemsSource = rthandler.GetReportTypes()
+End Sub
+```
+
+### 3. Open Form and Sync Selection
+```vb
+Private Sub ConfirmReportTypeButton_Click(sender As Object, e As RoutedEventArgs)
+    Dim selectedItem = ReportTypeCbo.SelectedItem
+
+    If selectedItem IsNot Nothing Then
+        Dim currentSelection As String = selectedItem.ToString()
+        Dim newSelection As String = rthandler.OnConfirmReportTypeButtonClick(currentSelection)
+
+        If Not String.IsNullOrWhiteSpace(newSelection) AndAlso newSelection <> currentSelection Then
+            ReportTypeCbo.SelectedItem = newSelection
+        End If
+    Else
+        MessageBox.Show("Please select a report type first.", "No Selection")
+    End If
+End Sub
+```
+
+### 4. Update `OnConfirmReportTypeButtonClick` to Pass and Return Value
+```vb
+Public Function OnConfirmReportTypeButtonClick(reportType As String) As String
+    Dim host As New ReportTypeHost()
+    Dim reportTypeView = CType(host.ElementHost1.Child, ReportTypeView)
+    reportTypeView.InitialSelectedReportType = reportType
+
+    host.ShowDialog()
+    Return reportTypeView.ReportTypeViewCbo.SelectedItem?.ToString()
+End Function
+```
+
+### 5. Initialize ComboBox in `ReportTypeView.xaml.vb`
+```vb
+Public Property InitialSelectedReportType As String
+
+Private Sub ReportTypeView_Loaded(sender As Object, e As RoutedEventArgs) Handles Me.Loaded
+    Dim reportTypes As List(Of String) = rthandler.GetReportTypes()
+    ReportTypeViewCbo.ItemsSource = reportTypes
+
+    If Not String.IsNullOrEmpty(InitialSelectedReportType) AndAlso reportTypes.Contains(InitialSelectedReportType) Then
+        ReportTypeViewCbo.SelectedItem = InitialSelectedReportType
+    End If
+End Sub
+```
+
+---
+
+## How to Reuse This Pattern for Other Controls
+
+1. **Define a Shared Data Method**
+   - Use a `List(Of String)` or other appropriate type.
+   - Place it in a shared handler or utility class.
+
+2. **Load the Data in Your Control**
+   - For WPF:
+     ```vb
+     MyComboBox.ItemsSource = SharedHandler.GetItems()
+     ```
+   - For WinForms:
+     ```vb
+     MyComboBox.Items.AddRange(SharedHandler.GetItems().ToArray())
+     ```
+
+3. **Sync Between Forms or Views**
+   - Pass the selected value via a public property.
+   - Use `ShowDialog()` to wait for the user's selection.
+   - Return the selected value and update the original control.
+
+4. **Validation (Optional but Recommended)**
+   - Always check for `Nothing` or empty selection.
+   - Notify users with a message box if needed.
+
+---
+
+## Benefits
+- Promotes DRY (Don't Repeat Yourself) principle
+- Works across WPF and WinForms
+- Makes forms easier to test and maintain
+- Keeps data centralized and consistent
+
+---
+
+## Future Improvements
+- Convert data source to load from config file or database
+- Add unit tests for shared data logic
+- Create a generic `ControlHelper` class to load lists into any control type
+

--- a/EZLogger/Handlers/ReportTypeHandler.vb
+++ b/EZLogger/Handlers/ReportTypeHandler.vb
@@ -1,14 +1,39 @@
-﻿Imports System.Windows
-Imports System.Windows.Forms
+﻿Imports System.Windows.Forms
 
 Namespace EZLogger.Handlers
 
-	Public Class ReportTypeHandler
-		Public Sub OnConfirmReportTypeButtonClick(reportType As String)
-			Dim host As New ReportTypeHost()
-			host.StartPosition = FormStartPosition.CenterScreen
-			host.Show()
-		End Sub
-	End Class
+    Public Class ReportTypeHandler
+
+        ' ✅ Called when the Confirm Type button is clicked
+        '    Shows the host form, passes in the selected report type, waits for user to finish,
+        '    then returns the selected value from the new form
+        Public Function OnConfirmReportTypeButtonClick(reportType As String) As String
+            Dim host As New ReportTypeHost()
+
+            ' Set the selected item on the WPF control inside the ElementHost
+            Dim reportTypeView = CType(host.ElementHost1.Child, ReportTypeView)
+            reportTypeView.InitialSelectedReportType = reportType
+
+            host.StartPosition = FormStartPosition.CenterScreen
+
+            ' Show the form modally
+            host.ShowDialog()
+
+            ' Return the selected value (or Nothing if user closed without selecting)
+            Return reportTypeView.ReportTypeViewCbo.SelectedItem?.ToString()
+        End Function
+
+        ' ✅ Shared function to return the list of report types
+        Public Function GetReportTypes() As List(Of String)
+            Return New List(Of String) From {
+                "1370(b)(1)",
+                "1372(a)(1)",
+                "UNLIKELY 1370(b)(1)",
+                "PPR"
+            }
+        End Function
+
+    End Class
+
 End Namespace
 

--- a/EZLogger/Views/ReportTypeView.xaml
+++ b/EZLogger/Views/ReportTypeView.xaml
@@ -13,7 +13,7 @@
             <StackPanel Height="80" Width="440" Orientation="Horizontal">
                 <StackPanel Height="80" Width="220" VerticalAlignment="Top">
                     <GroupBox Height="70" Header="Report Type" Width="200" BorderBrush="DarkGray" VerticalAlignment="Top">
-                        <ComboBox HorizontalAlignment="Left" Width="185" Height="31"/>
+                        <ComboBox x:Name="ReportTypeViewCbo" HorizontalAlignment="Left" Width="185" Height="31"/>
                     </GroupBox>
                 </StackPanel>
                 <StackPanel Height="80" Width="220" VerticalAlignment="Top">

--- a/EZLogger/Views/ReportTypeView.xaml.vb
+++ b/EZLogger/Views/ReportTypeView.xaml.vb
@@ -1,3 +1,24 @@
-﻿Public Class ReportTypeView
+﻿' Top of the file
+Imports EZLogger.EZLogger.Handlers
+Imports System.Collections.Generic
+Imports System.Windows
+
+Public Class ReportTypeView
+
+    ' ✅ 1. Property to receive selected report type
+    Public Property InitialSelectedReportType As String
+
+    ' ✅ 2. Handler for shared report types
+    Private rthandler As New ReportTypeHandler()
+
+    ' ✅ 3. When the view loads, populate and set selection
+    Private Sub ReportTypeView_Loaded(sender As Object, e As RoutedEventArgs) Handles Me.Loaded
+        Dim reportTypes As List(Of String) = rthandler.GetReportTypes()
+        ReportTypeViewCbo.ItemsSource = reportTypes
+
+        If Not String.IsNullOrEmpty(InitialSelectedReportType) AndAlso reportTypes.Contains(InitialSelectedReportType) Then
+            ReportTypeViewCbo.SelectedItem = InitialSelectedReportType
+        End If
+    End Sub
 
 End Class

--- a/EZLogger/Views/ReportWizardPanel.xaml.vb
+++ b/EZLogger/Views/ReportWizardPanel.xaml.vb
@@ -1,6 +1,7 @@
 ﻿Imports System.Windows
 Imports System.Windows.Controls
 Imports EZLogger.EZLogger.Handlers
+Imports System.Collections.Generic
 
 Partial Public Class ReportWizardPanel
     Inherits Controls.UserControl
@@ -20,21 +21,10 @@ Partial Public Class ReportWizardPanel
         End If
     End Sub
     Private Sub ReportWizardPanel_Loaded(sender As Object, e As RoutedEventArgs) Handles Me.Loaded
-        Dim reportTypes As New List(Of String) From {
-        "1370(b)(1)",
-        "UNLIKELY 1370(b)(1)",
-        "1372(a)(1)",
-        "PPR",
-        "1026.5(b)(1)",
-        "2972",
-        "1026.2(l)",
-        "1026.2(b)"
-    }
+        ReportTypeCbo.ItemsSource = rthandler.GetReportTypes()
 
-        ReportTypeCbo.ItemsSource = reportTypes
         ' Simulated database value — later this will come from a database or config
         Dim courtNumbers As String = "123456H; 2344R5; 33456T; 33RRT5; 667788H; 9988-STC-456; VVR-45678; 1"
-
         CourtNumbersTextBlock.Text = courtNumbers
     End Sub
 
@@ -47,15 +37,22 @@ Partial Public Class ReportWizardPanel
     End Sub
 
     Private Sub ConfirmReportTypeButton_Click(sender As Object, e As RoutedEventArgs)
-        'Dim selectedItem As ComboBoxItem = TryCast(ReportTypeCbo.SelectedItem, ComboBoxItem)
-        Dim selectedItem As String = TryCast(ReportTypeCbo.SelectedItem, String)
+        Dim selectedItem = ReportTypeCbo.SelectedItem
 
         If selectedItem IsNot Nothing Then
-            'Dim reportType As String = selectedItem.Content.ToString()
-            rthandler.OnConfirmReportTypeButtonClick(selectedItem)
+            Dim currentSelection As String = selectedItem.ToString()
+
+            ' Show the form and get the updated value
+            Dim newSelection As String = rthandler.OnConfirmReportTypeButtonClick(currentSelection)
+
+            ' Update ComboBox if the value changed
+            If Not String.IsNullOrWhiteSpace(newSelection) AndAlso newSelection <> currentSelection Then
+                ReportTypeCbo.SelectedItem = newSelection
+            End If
         Else
             MessageBox.Show("Please select a report type first.", "No Selection")
         End If
     End Sub
+
 
 End Class

--- a/temp/global_config.json
+++ b/temp/global_config.json
@@ -1,0 +1,130 @@
+{
+    "_comment":    "EZLogger Global Configuration File",
+    "this_config": {
+        "_comment":    "Identifies this config file type or scope",
+        "name":        "global config"
+    },
+    "edo_filepath": {
+        "_comment":            "Paths used by the EDO (Forensic Office) for templates, logs, and audit files",
+        "cot_list":            "",
+        "court_fax":           "",
+        "da_fax":              "",
+        "error_folder":        "",
+        "ist_cert":            "",
+        "ppr_cover":           "",
+        "processed_log":       "",
+        "processed_tcars":     "",
+        "report_history":      "",
+        "sheriff_fax":         "",
+        "tcar_xl_log":         ""
+    },
+    "cdo_filepath": {
+        "_comment":            "Paths for CDO report tracking files and visit logs",
+        "hlv_due":             "",
+        "post_trial_1026":     "",
+        "post_trial_2972":     "",
+        "pre_trial_1370":      ""
+    },
+    "Alerts": {
+        "215715-4":    "Jesse Lucatero - for any reports processed on this case, please send a copy to Judicial Assistant Troy Podratz (TPodratz@lacourt.org) CM",
+        "218048-7":    "Amber Brown - SUPER RUSH due 03-May - 05/02-BL",
+        "219124-5":    "Daryl Shreve is on the CARE court list 02/26",
+        "219596-4":    "Kelley is on the CARE court list 02/20",
+        "_comment":    "Patient-specific alerts: Patient ID -> Message shown when processing their reports"
+    },
+    "Weekly": {
+        "_comment":    "Location of the currently active weekly Excel tracker",
+        "current":     ""
+    },
+    "listbox": {
+        "_comment":    "Values used to populate list boxes and combo boxes in forms",
+        "report_type": [
+            "PPR",
+            "1026.2(l)",
+            "1026.2(b)",
+            "COT",
+            "1026.5(b)(1)",
+            "2972",
+            "1370(b)(1)",
+            "1372(a)(1)",
+            "1372(e)",
+            "UNLIKELY 1370(b)(1)",
+            "UNLIKELY 1370(c)(1)"
+        ],
+        "opinions": [
+            "Competent",
+            "Not Yet Competent",
+            "UNLIKELY",
+            "Malingering",
+            "Restored",
+            "Retain and Treat"
+        ],
+        "cover_pages": [
+            "A. Convert This Document to PDF",
+            "B. Court Fax Cover Sheet",
+            "C. Sheriff Fax Cover Sheet",
+            "D. CONREP Fax Cover Sheet",
+            "E. DA Fax Cover Sheet",
+            "F. [Deprecated] Periodic Progress Report 1026(f) Cover Letter",
+            "G. WIC 6316.2 MDSO Ext Cover and Affidavit",
+            "H. 1026.5(b)(1) NOT Extending Commitment Cover",
+            "I. 1026.5(b)(1) Extension Cover and Affidavit",
+            "J. 2972 Renewal Cover and Affidavit",
+            "K. 1370 90-Day Proximal to 9-Month",
+            "L. 1372(e) CERT",
+            "M. 1372(a)(1) CERT",
+            "N. UNLIKELY(b)(1) Sheriff Cover Letter",
+            "O. UNLIKELY(c)(1) Court Cover Letter",
+            "P. UNLIKELY(c)(1) Sheriff Cover Letter",
+            "Q. UNLIKELY(b)(1) Court Cover Letter",
+            "R. TCAR Updated Email",
+            "S.Court Email",
+            "T.Sheriff Email"
+        ]
+    },
+    "log_files": {
+        "IST":         "",
+        "MDO":         "",
+        "NGI":         "",
+        "_comment":    "Paths to Excel logs for different legal categories"
+    },
+    "log_files_status_bar": {
+        "IST":         "Log 1370(b)(1), 1372(a)(1), and Unlikelies. Will log:",
+        "MDO":         "Log 2972 Renewals. Will log:",
+        "NGI":         "Log 1026(f), 1026.2(l), 1026.2(b), COT, and 1026.5(b)(1). Will log:",
+        "_comment":    "Short summary of what each log type covers"
+    },
+    "email_list": {
+        "_comment":    "Shared email lists used in automation (e.g. for sending notifications or documents)",
+        "secretaries": [
+            "Kristi.Moreno@dsh.ca.gov",
+            "Hilda.Garcia@dsh.ca.gov",
+            "Keyara.Hutcheson@dsh.ca.gov",
+            "Crystal.Garrison@dsh.ca.gov",
+            "Dawn.Marcacci@dsh.ca.gov",
+            "Chloe.Casilang@dsh.ca.gov",
+            "Kevin.Decara@dsh.ca.gov"
+        ]
+    },
+    "version": {
+        "_comment":            "Version and maintenance info for the config",
+        "date":                "2025-01-31",
+        "instructions":        "fixed error handling when patient number doesn't match database",
+        "number":              "2.6.1",
+        "support_email":       "Bryan.Lundeen@dsh.ca.gov"
+    },
+    "county_alerts": {
+        "BUTTE":           "Please check forensic info for changes to the court number and judge name",
+        "KERN":            "Check with court clerk before faxing. They often require a phone confirmation.",
+        "LOS ANGELES":     "Use internal e-filing only. Include form CR-206 if available.",
+        "MADERA":          "No fax. Must mail originals to the court.",
+        "ORANGE":          "Fax AND mail required to meet deadline. Include cover letter and DA copy.",
+        "RIVERSIDE":       "Send to court using e-Submit. (see OneNote)",
+        "SACRAMENTO":      "Use the new fax number ending in -8579. See OneNote if uncertain.",
+        "SAN DIEGO":       "Fax is not used. Use e-filing platform and include court form MC-025.",
+        "SAN JOAQUIN":     "Don't send reports to San Joaquin with a cover page. Email them to the clerk via the shared address. See OneNote.",
+        "TULARE":          "DO NOT fax. All reports must be mailed or e-filed using Tyler.",
+        "YUBA":            "Send by mail only. Court requires original signature pages.",
+        "_comment":        "Displays special alert messages per county during processing or printing"
+    }
+}

--- a/temp/local_user_config.json
+++ b/temp/local_user_config.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "EZLogger Local User Configuration File - last updated 2024-12-19",
+
+  "this_config": {
+    "_comment": "Identifies this as a user-specific config file",
+    "name": "user config"
+  },
+
+  "sp_filepath": {
+    "_comment": "Local file paths used by the user for templates, contact databases, and shared config references",
+    "templates": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Templates",
+    "user_forensic_library": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Forensic Reports Library",
+    "user_forensic_database": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases",
+    "global_config_file": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases\\ez_logger_global_config.json",
+    "properties_list": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases\\document_properties.txt",
+    "doctors_list": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases\\Doctors.txt",
+    "sheriff_addresses": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases\\Sheriff_Addresses.xlsx",
+    "da_contact_database": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases\\Da_Contact_Database.xlsx",
+    "court_contact": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases\\Court_Contact_Database.xlsx",
+    "hlv_due": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases\\HLV Due for Visit.txt",
+    "hlv_data": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases\\HLV_Report_Database.xlsm",
+    "ods_filepath": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases\\ODS.xlsm",
+    "databases": "C:\\Users\\USERNAME\\Documents\\EZLogger\\Databases"
+  },
+
+  "edo_filepath": {
+    "_comment": "Shortcuts to shared drive paths, relative to a network root",
+    "processed_reports": "\\Programming\\EZ Logger\\ProcessedReports",
+    "forensic_office": "\\\\Mhnfs1\\edo\\FCLSGRP\\Forensic Office",
+    "tcars_folder": "\\1370 FS Report Tracking"
+  }
+}


### PR DESCRIPTION
This pull request introduces a shared ComboBox population and syncing strategy for report types in the EZLogger application. The changes include the creation of a shared method for retrieving report types, modifications to the `ReportWizardPanel` and `ReportTypeView` to use this shared method, and updates to configuration files to support the new functionality.

### Shared ComboBox Population and Syncing Strategy:

* **Documentation**:
  * Added a detailed document explaining the shared ComboBox population and syncing strategy, including how to reuse the pattern for other controls. (`.notes/Using this for all ReportType ComboBoxes.md`)

* **Shared Method**:
  * Created a shared method `GetReportTypes` in `ReportTypeHandler` to return a list of report types. (`EZLogger/Handlers/ReportTypeHandler.vb`)

* **UI Updates**:
  * Modified `ReportWizardPanel` to use the shared `GetReportTypes` method for populating the ComboBox. (`EZLogger/Views/ReportWizardPanel.xaml.vb`)
  * Updated `ReportTypeView` to initialize the ComboBox with the shared report types and sync the selected item with `ReportWizardPanel`. (`EZLogger/Views/ReportTypeView.xaml.vb`)

* **Configuration Files**:
  * Added new fields to `global_config.json` and `local_user_config.json` to support the ComboBox and other control values. (`temp/global_config.json`, `temp/local_user_config.json`) [[1]](diffhunk://#diff-2a5e954c3c8fd36a7e64f7b3a05d06df5cdf84bd443015204cf690e98651081eR1-R130) [[2]](diffhunk://#diff-1db0d8f0e714de240e1408bd94a23e4e182b5457f56ba039768cb5f207bdb8e1R1-R32)

These changes ensure a consistent and maintainable approach to populating and syncing ComboBoxes across different forms in the application.